### PR TITLE
Review constributing guidelines

### DIFF
--- a/.github/workflows/R-CMD-check-macos.yaml
+++ b/.github/workflows/R-CMD-check-macos.yaml
@@ -94,7 +94,7 @@ jobs:
         uses: peter-evans/repository-dispatch@v1
         with:
           token: ${{ secrets.REPO_GHA_PAT }}
-          repository: statnmap/gitlabr
+          repository: ${{ github.repository }}
           event-type: R-CMD-check-windows
           client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'
           

--- a/.github/workflows/R-CMD-check-ubuntu-devel.yaml
+++ b/.github/workflows/R-CMD-check-ubuntu-devel.yaml
@@ -90,6 +90,6 @@ jobs:
         uses: peter-evans/repository-dispatch@v1
         with:
           token: ${{ secrets.REPO_GHA_PAT }}
-          repository: statnmap/gitlabr
+          repository: ${{ github.repository }}
           event-type: test-coverage
           client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'

--- a/.github/workflows/R-CMD-check-ubuntu-release.yaml
+++ b/.github/workflows/R-CMD-check-ubuntu-release.yaml
@@ -90,7 +90,7 @@ jobs:
         uses: peter-evans/repository-dispatch@v1
         with:
           token: ${{ secrets.REPO_GHA_PAT }}
-          repository: statnmap/gitlabr
+          repository: ${{ github.repository }}
           event-type: R-CMD-check-ubuntu-devel
           client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'
           

--- a/.github/workflows/R-CMD-check-windows.yaml
+++ b/.github/workflows/R-CMD-check-windows.yaml
@@ -90,7 +90,7 @@ jobs:
         uses: peter-evans/repository-dispatch@v1
         with:
           token: ${{ secrets.REPO_GHA_PAT }}
-          repository: statnmap/gitlabr
+          repository: ${{ github.repository }}
           event-type: R-CMD-check-ubuntu-release
           client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'
           

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,53 +1,64 @@
-# Contributing to gitlabr
+# Contributing to {gitlabr}
 
-You're welcome to contribute to gitlabr by editing the source code, adding more convenience functions, filing issues, etc. This document compiles some information helpful in that process.
+You're welcome to contribute to {gitlabr} by editing the source code, adding more convenience functions, filing issues, etc. This document compiles some information helpful in that process.
 
 Please also note the [Code of Conduct](CONDUCT.md).
 
 
-## Setup a local development environment
+## Setup a development environment
 
-If you want to run the test suite locally, you need to setup a Gitlab instance for testing. Then, in the file `tests/environment.yml` configuration variables are recorded about how to connect to the gitlab instance. [tests/environment.yml.example](tests/environment.yml.example) contains an example configuration for a server that is, however, not publicly available for a testing.
+The gitlab test suite expects certain entities (user, project, files, comments)
+to be present in the test server. Below are the guidelines to setup a Gitlab
+instance and the local file `tests/environment.yml`. Note that
+<https://gitlab.com/KevCaz/testor> was created following these guidelines. 
 
-## How to create a test server
 
-The gitlab test suite expects certain entities (user, project, files) to be present in the test server. Here is how to setup a test server:
+1. Install & make gitlab instance reachable at a certain address. The easiest way is to use either a docker image of the gitlab version of interest or <https://gitlab.com>. 
 
-- install & make gitlab instance reachable at a certain address (The easiest way is to use the a docker image of the gitlab version of interest or use https://gitlab.com)
-- create a user
-  + Add your username in environment.yml as GITLABR_TEST_LOGIN
-  + Add your user ID in environment.yml as GITLABR_TEST_LOGIN_ID (numeric)
-    + Go to your profile (like https://gitlab.com/profile) and find your User ID
-  + Add your user password in environment.yml as GITLABR_TEST_PASSWORD
-- generate a private access token for the user for the complete API
-  + For instance on Gitlab.com: https://gitlab.com/profile/personal_access_tokens
-  + Add in the environment.yml or environment variables as "GITLABR_TEST_TOKEN"
-- create a project called `testor`, owned by the user, and containing a README.md file
+2. Create a user
+  + Add your username in `environment.yml` as `GITLABR_TEST_LOGIN`
+  + Add your user ID in `environment.yml` as `GITLABR_TEST_LOGIN_ID` (numeric)
+    + Go to your profile (e.g. https://gitlab.com/profile) and look up for your User ID
+  + Add your user password in `environment.yml` as `GITLABR_TEST_PASSWORD`
+  
+3. Generate a private access token for the user that grants all read/write access to the  API 
+  + For instance on gitlab.com: https://gitlab.com/profile/personal_access_tokens
+  + Tick the fist checkboxes (the `api` scope) 
+  + Add in the `environment.yml` or environment variables as "GITLABR_TEST_TOKEN"
+  
+4. create a project called `testor`, owned by the user, and containing a README.md file
   + New Project > Initialize with a README
-  + Add this name in the environment.yml as variable named "GITLABR_TEST_PROJECT_NAME"
-- get the ID of the project and note it in the environment.yml as variable named 'GITLABR_TEST_PROJECT_ID'
+  + Add this name in the `environment.yml` as variable named "GITLABR_TEST_PROJECT_NAME"
+  
+5. get the ID of the project and add it in `environment.yml` as variable named 'GITLABR_TEST_PROJECT_ID'
   + Project Overview > Details
   + The Project ID is under the name of your project
-- give it a CI file that writes to a "test.txt" file
-- create an issue #1 with a comment
-  + Issues > List > New issue
-  + Add title and description > Open
-  + Add comment
-- Comment on a commit and note its SHA1 in the environment.yml as variable named 'COMMENTED_COMMIT'
-  + Repository > Commits
-  + Click on one commit
-  + Write a comment > Comment
-  + Find the <SHA1> of the commit
-- Create a branch named "for-tests"
-
-- On your computer:
-  + Clone the repository
-    + Rstudio > New project > Version control > git 
-    + Or git clone https://.....testor.git
-  + Copy the content of "dev/testor" in the directory
-    + It contains a R package with CI for tests
-  + Send to the _master_ on the server
   
+6. Add and commit a CI file (`.gitlab-ci.yml`) that includes a job named `testing` that should minimally create `public/coverage.html` as an artifact, we recommend using the following `.gitlab-ci.yml` file:
+
+```yaml 
+testing:
+  script: mkdir public; echo "test 1 2 1 2" > public/coverage.html 
+  artifacts:
+    paths:
+      - public/coverage.html
+```
+
+7. Create a commit (or use the commit just created), add a follow-up comment and add its 40-character SHA-1 hash in the `environment.yml` as variable named 'COMMENTED_COMMIT', to do so:
+  + Go to Repository > Commits
+  + Copy the <SHA1> of the relevant commit 
+  + Click on the relevant commit 
+  + Write a comment 
+  
+8. Create a first issue (#1) with a follow-up comment
+  + Go to Issues > List > New issue
+  + Add a title and a description for the issue then click on `Submit issue`
+  + Then add a follow-up comment to this issue
+
+9. Go to Repository > Branches and create a branch named "for-tests".
+
+
+
   
 ### How to run the test suite
 
@@ -59,6 +70,27 @@ library(yaml)
 do.call(Sys.setenv, yaml.load_file("tests/environment.yml")) ## load test environment variables
 test() ## run tests
 ```
+
+
+### How to check the package with GitHub Actions on your own fork
+
+For GitHub users, it is possible to directly use [GitHub Actions](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions) to test whether the package can be build smoothly before creating a PR. To do so, they should add the following environmental variables (the ones listed in `environment.yml`) as [encrypted secrets](https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets),
+
+- COMMENTED_COMMIT
+- GITLABR_TEST_LOGIN
+- GITLABR_TEST_LOGIN_ID
+- GITLABR_TEST_PASSWORD
+- GITLABR_TEST_PROJECT_ID
+- GITLABR_TEST_PROJECT_NAME
+- GITLABR_TEST_TOKEN
+- GITLABR_TEST_URL
+
+Also, another encrypted secrets named `REPO_GHA_PAT` is required, it should include a 
+[personal access token](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token) that has access to your GitHub repositories.
+
+
+
+
 
 ### API version
 

--- a/R/ci.R
+++ b/R/ci.R
@@ -175,7 +175,6 @@ gl_builds <- function(project, api_version = 4, ...) {
 #' @return returns the file path if \code{save_to_file} is TRUE, or the archive as raw otherwise.
 gl_latest_build_artifact <- function(project, job, ref_name = "master", save_to_file = tempfile(fileext = ".zip"), ...) {
   
-  
   raw_build_archive <- gitlab(gl_proj_req(project = project,
                                           c("jobs", "artifacts", ref_name, "download"),
                                           ...),

--- a/tests/testthat/test_issues.R
+++ b/tests/testthat/test_issues.R
@@ -44,7 +44,7 @@ test_that("getting issues works", {
   expect_is(gl_get_issue(new_issue_iid, gitlab_con = my_project, api_version = test_api_version), "data.frame")
 
   ## old API
-  if(test_api_version == 4) {
+  if (test_api_version == 4) {
     expect_warning(my_gitlab(get_issues), regexp = "deprecated")
   }
 })


### PR DESCRIPTION
In this PR I have reviewed the guidelines to set up a `testor` repository to be able to test {gitlabr} (as discussed in #10). I therefore maily focused on editing `CONTRIBUTING.md`. I have 2 additional suggestions that I would be happy to add to this PR:

First, I think `.gitlab-ci.yml` in `testor` can be simplified, so far I've used 


```yaml
testing:
  script: mkdir public; echo "test 1 2 1 2" > public/coverage.html 
  artifacts:
    paths:
      - public/coverage.html
```

because of the following test: 

https://github.com/statnmap/gitlabr/blob/773614f5a67884531e1ac38bb9a16f6a1566c218/tests/testthat/test_ci.R#L49

But, IMHO, it would make more sense to use: 


```yaml 
testing:
  script: echo 'test 1 2 1 2' > 'test.txt'
  artifacts:
    paths:
      - test.txt
```

and change `test_ci.R` accordingly. Second I think `dev/testor` can now be dropped.


Last, I have fixed 2 typos and replaced `stanmap/gitlabr` by `${{ github.repository }} `in step `Trigger coverage` so the workflows can be used across forks. The code run well, locally all the tests passed except the following one that sometimes passes and sometimes does not, which I think explains why I cannot make all the workflows work on my fork.

https://github.com/statnmap/gitlabr/blob/773614f5a67884531e1ac38bb9a16f6a1566c218/tests/testthat/test_issues.R#L62
