### PR TITLE
Use `PRIVATE-TOKEN` header to send private access token

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,8 +35,8 @@ Suggests:
     yaml
 VignetteBuilder: 
     knitr
+Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.2
-Config/testthat/edition: 3

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,8 @@
 
 New
 
-* `gl_list_group_projects()` lists projects of a group thanks to @Yoshinobu-Ishizaki
+* Connection now uses the token as "header" instead of being sent clearly in the URL (#66, @ei-ds) 
+* `gl_list_group_projects()` lists projects of a group (@Yoshinobu-Ishizaki)
 
 # gitlabr 2.0.0
 

--- a/R/connect.R
+++ b/R/connect.R
@@ -79,7 +79,7 @@ gl_project_connection <- function(gitlab_url,
                                   api_version = 4,
                                   api_location = paste0("/api/v", api_version, "/")) {
   
-  gl_con_root <- paste0(gitlab_url, api_location)
+  gl_con_root <- httr::modify_url(gitlab_url, path = api_location)
 
   return(function(req, ...) {
     if (is.function(req)) {

--- a/R/gitlab_api.R
+++ b/R/gitlab_api.R
@@ -112,15 +112,13 @@ gitlab <- function(req,
       iff(debug, print) -> resp$ct
     
     if (page == "all") {
-      private_token <- list(...)[["private_token"]]
       # pages_retrieved <- 0L
       pages_retrieved <- 1L
       while (length(resp$nxt) > 0 && is.finite(max_page) && pages_retrieved < max_page) {
         nxt_resp <- resp$nxt %>%
           as.character() %>%
           iff(enforce_api_root, stringr::str_replace, "^.*/api/v\\d/", api_root) %>%
-          paste0("&private_token=", private_token) %>%
-          httr::GET() %>%
+          httr::GET(httr::add_headers("PRIAVTE-TOKEN" = private_token)) %>%
           http_error_or_content()
         resp$nxt <- nxt_resp$nxt
         resp$ct <- bind_rows(resp$ct, nxt_resp$ct %>%

--- a/R/gitlab_api.R
+++ b/R/gitlab_api.R
@@ -99,6 +99,7 @@ gitlab <- function(req,
       iff(debug, function(x) { print(paste(c("URL:", x, " "
                                              , "query:", paste(utils::capture.output(print((list(...)))), collapse = " "), " ", collapse = " "))); x })
     
+    # Extract private token to put it in header
     l <- list(...)
     private_token <- l$private_token
     l <- within(l, rm(private_token))

--- a/R/gitlab_api.R
+++ b/R/gitlab_api.R
@@ -102,9 +102,10 @@ gitlab <- function(req,
     l <- list(...)
     private_token <- l$private_token
     l <- within(l, rm(private_token))
+    private_token_header <- httr::add_headers("PRIVATE-TOKEN" = private_token)
     
     (if (page == "all") {l} else { c(page = page, l)}) %>%
-      pipe_into(argname_verb, verb, url = url, httr::add_headers("PRIVATE-TOKEN" = private_token)) %>%
+      pipe_into(argname_verb, verb, url = url, private_token_header) %>%
       http_error_or_content()   -> resp
     
     resp$ct %>%
@@ -118,7 +119,7 @@ gitlab <- function(req,
         nxt_resp <- resp$nxt %>%
           as.character() %>%
           iff(enforce_api_root, stringr::str_replace, "^.*/api/v\\d/", api_root) %>%
-          httr::GET(httr::add_headers("PRIAVTE-TOKEN" = private_token)) %>%
+          httr::GET(private_token_header) %>%
           http_error_or_content()
         resp$nxt <- nxt_resp$nxt
         resp$ct <- bind_rows(resp$ct, nxt_resp$ct %>%

--- a/R/gitlab_api.R
+++ b/R/gitlab_api.R
@@ -99,8 +99,12 @@ gitlab <- function(req,
       iff(debug, function(x) { print(paste(c("URL:", x, " "
                                              , "query:", paste(utils::capture.output(print((list(...)))), collapse = " "), " ", collapse = " "))); x })
     
-    (if (page == "all") {list(...)} else { list(page = page, ...)}) %>%
-      pipe_into(argname_verb, verb, url = url) %>%
+    l <- list(...)
+    private_token <- l$private_token
+    l <- within(l, rm(private_token))
+    
+    (if (page == "all") {l} else { c(page = page, l)}) %>%
+      pipe_into(argname_verb, verb, url = url, httr::add_headers("PRIVATE-TOKEN" = private_token)) %>%
       http_error_or_content()   -> resp
     
     resp$ct %>%

--- a/man/use_gitlab_ci.Rd
+++ b/man/use_gitlab_ci.Rd
@@ -22,7 +22,8 @@ use_gitlab_ci(
 
 \item{overwrite}{whether to overwrite existing GitLab CI yml file}
 
-\item{add_to_Rbuildignore}{add CI yml file (from \code{path}) to .Rbuildignore?}
+\item{add_to_Rbuildignore}{add CI yml file and cache path used inside the
+CI workflow to .Rbuildignore?}
 
 \item{type}{type of the CI template to use}
 }

--- a/tests/testthat/test_pagination.R
+++ b/tests/testthat/test_pagination.R
@@ -15,7 +15,7 @@ test_that("Pagination produces the same results", {
   users_2_1 <- gitlab("users", per_page = 2, page = 1)
   expect_true(nrow(users_2_1) == 2)
   expect_true(nrow(users_2_2) == 2)
-  expect_equal(nrow(setdiff(users_2_1, users_2_2)), 2)
+  expect_equal(nrow(dplyr::setdiff(users_2_1, users_2_2)), 2)
   
   # Get all pages (default) until max_page
   users_all <- gitlab("users", page = "all", max_page = 2)

--- a/vignettes/c-alternative-connection-to-projects.Rmd
+++ b/vignettes/c-alternative-connection-to-projects.Rmd
@@ -78,3 +78,17 @@ my_gitlab(gl_create_issue, title = "Implement new feature", project = "<my-proje
 
 Some of the convenience functions perform additional transformation or renaming of parameters.
 Hence, the parameters given to the exemplary `my_gitlab(...)` call after the function should be valid according to the specified function's documentation, and may differ from names used in the GitLab API itself, although this occurs only very rarely.
+
+## Define a custom function with `gitlab()` and a temporary connection
+
+All API possibilities are not available in {gitlabr}. You can look at vignette "Go further: understand and build your functions" if you want to build your own API function.  
+Using a `gitlab()`, out of the recommended way for connection, requires using the `gitlab_con` parameter as follows.
+
+```{r}
+gitlab(
+  c("projects", "<my-project-id>", "issues"),
+  gitlab_con = gl_connection("https://gitlab.com",
+                           private_token = Sys.getenv("GITLAB_COM_TOKEN"))
+)
+```
+


### PR DESCRIPTION
This PR relates to #66.

It is just an example how to send the private access token as the `PRIVATE-TOKEN` header in the API requests.

I'm not sure if this is the preferred way as it seems ugly to extract the PAT from `...`. I'm very open for suggestions to improve.