### PR TITLE
fix: enable coverage badge

### DIFF
--- a/inst/gitlab-ci/check-coverage-pkgdown-renv.yml
+++ b/inst/gitlab-ci/check-coverage-pkgdown-renv.yml
@@ -1,4 +1,4 @@
-image: {image}
+image: { image }
 
 variables:
   RENV_PATHS_CACHE: "cache"
@@ -10,9 +10,9 @@ variables:
 cache:
   key: global-cache
   paths:
-      - ${RENV_PATHS_CACHE}
-      - ${RENV_PATHS_LIBRARY}
-      - ${R_LIBS_USER}
+    - ${RENV_PATHS_CACHE}
+    - ${RENV_PATHS_LIBRARY}
+    - ${R_LIBS_USER}
 
 stages:
   - build
@@ -36,10 +36,10 @@ building:
     - Rscript -e 'remotes::install_local(upgrade = "never")'
     - R -e 'rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check")'
   artifacts:
-      paths:
-          - check
-      expire_in: 30 days
-      
+    paths:
+      - check
+    expire_in: 30 days
+
 # To have the coverage percentage appear as a gitlab badge follow these
 # instructions:
 # https://docs.gitlab.com/ee/user/project/pipelines/settings.html#test-coverage-parsing
@@ -47,120 +47,121 @@ building:
 # Coverage: \d+\.\d+
 
 coverage:
-    stage: test
-    allow_failure: true
-    when: on_success
-    only:
-        - master
-        - main
-        - production
-    script:
-        - Rscript -e 'source("renv/activate.R")'
-        - Rscript -e 'install.packages("remotes")'
-        - Rscript -e 'remotes::install_cran(c("covr", "DT"), upgrade = "never")'
-        - Rscript -e 'renv::restore()'
-        - Rscript -e 'covr::gitlab(quiet = FALSE)'
-    artifacts:
-        paths:
-            - public
-        expire_in: 30 days
+  stage: test
+  allow_failure: true
+  when: on_success
+  only:
+    - master
+    - main
+    - production
+  script:
+    - Rscript -e 'source("renv/activate.R")'
+    - Rscript -e 'install.packages("remotes")'
+    - Rscript -e 'remotes::install_cran(c("covr", "DT"), upgrade = "never")'
+    - Rscript -e 'renv::restore()'
+    - Rscript -e 'covr::gitlab(quiet = FALSE)'
+  coverage: '/Coverage: \d+\.\d+/'
+  artifacts:
+    paths:
+      - public
+    expire_in: 30 days
 
 # To produce a code coverage report as a GitLab page see
 # https://about.gitlab.com/2016/11/03/publish-code-coverage-report-with-gitlab-pages/
 
 integration:
-    stage: pkgdown
-    allow_failure: true
-    when: on_success
-    only:
-        - master
-        - main
-        - production
-        - test-ci
-    script:
-        - Rscript -e 'source("renv/activate.R")'
-        - Rscript -e 'install.packages("remotes")'
-        - Rscript -e 'remotes::install_cran(c("pkgdown"), upgrade = "never")'
-        - Rscript -e 'renv::restore()'
-        - Rscript -e 'remotes::install_local(upgrade = "never")'
-        - Rscript -e 'pkgdown::build_site()'
-    artifacts:
-        paths:
-            - docs
-        expire_in: 30 days
+  stage: pkgdown
+  allow_failure: true
+  when: on_success
+  only:
+    - master
+    - main
+    - production
+    - test-ci
+  script:
+    - Rscript -e 'source("renv/activate.R")'
+    - Rscript -e 'install.packages("remotes")'
+    - Rscript -e 'remotes::install_cran(c("pkgdown"), upgrade = "never")'
+    - Rscript -e 'renv::restore()'
+    - Rscript -e 'remotes::install_local(upgrade = "never")'
+    - Rscript -e 'pkgdown::build_site()'
+  artifacts:
+    paths:
+      - docs
+    expire_in: 30 days
 
 integration-test:
-    stage: pkgdown-move
-    dependencies:
-        - integration
-    only:
-        - test-ci
-    script:
-        - mkdir -p public/test
-        - 'curl --location --output artifacts.zip --header "JOB-TOKEN: $CI_JOB_TOKEN" "$CI_API_V4_URL/projects/$CI_PROJECT_ID/jobs/artifacts/$CI_DEFAULT_BRANCH/download?job=pages" &&
-          unzip artifacts.zip &&
-          rm artifacts.zip &&
-          echo "copied $CI_DEFAULT_BRANCH artifacts" ||
-          echo "copied $CI_DEFAULT_BRANCH artifacts failed"'
-        - 'curl --location --output artifacts.zip --header "JOB-TOKEN: $CI_JOB_TOKEN" "$CI_API_V4_URL/projects/$CI_PROJECT_ID/jobs/artifacts/production/download?job=pages" &&
-          unzip artifacts.zip &&
-          rm artifacts.zip &&
-          echo "copied production artifacts" ||
-          echo "copied production artifacts failed"'
-        - cp -r docs/* public/test
-    artifacts:
-        paths:
-            - public
-        expire_in: 30 days
+  stage: pkgdown-move
+  dependencies:
+    - integration
+  only:
+    - test-ci
+  script:
+    - mkdir -p public/test
+    - 'curl --location --output artifacts.zip --header "JOB-TOKEN: $CI_JOB_TOKEN" "$CI_API_V4_URL/projects/$CI_PROJECT_ID/jobs/artifacts/$CI_DEFAULT_BRANCH/download?job=pages" &&
+      unzip artifacts.zip &&
+      rm artifacts.zip &&
+      echo "copied $CI_DEFAULT_BRANCH artifacts" ||
+      echo "copied $CI_DEFAULT_BRANCH artifacts failed"'
+    - 'curl --location --output artifacts.zip --header "JOB-TOKEN: $CI_JOB_TOKEN" "$CI_API_V4_URL/projects/$CI_PROJECT_ID/jobs/artifacts/production/download?job=pages" &&
+      unzip artifacts.zip &&
+      rm artifacts.zip &&
+      echo "copied production artifacts" ||
+      echo "copied production artifacts failed"'
+    - cp -r docs/* public/test
+  artifacts:
+    paths:
+      - public
+    expire_in: 30 days
 
 integration-production:
-    stage: pkgdown-move
-    dependencies:
-        - integration
-    only:
-        - production
-    script:
-        - mkdir -p public/production
-        - 'curl --location --output artifacts.zip --header "JOB-TOKEN: $CI_JOB_TOKEN" "$CI_API_V4_URL/projects/$CI_PROJECT_ID/jobs/artifacts/$CI_DEFAULT_BRANCH/download?job=pages" &&
-          unzip artifacts.zip &&
-          rm artifacts.zip &&
-          echo "copied $CI_DEFAULT_BRANCH artifacts" ||
-          echo "copied $CI_DEFAULT_BRANCH artifacts failed"'
-        - cp -r docs/* public/production
-    artifacts:
-        paths:
-            - public
-        expire_in: 30 days
+  stage: pkgdown-move
+  dependencies:
+    - integration
+  only:
+    - production
+  script:
+    - mkdir -p public/production
+    - 'curl --location --output artifacts.zip --header "JOB-TOKEN: $CI_JOB_TOKEN" "$CI_API_V4_URL/projects/$CI_PROJECT_ID/jobs/artifacts/$CI_DEFAULT_BRANCH/download?job=pages" &&
+      unzip artifacts.zip &&
+      rm artifacts.zip &&
+      echo "copied $CI_DEFAULT_BRANCH artifacts" ||
+      echo "copied $CI_DEFAULT_BRANCH artifacts failed"'
+    - cp -r docs/* public/production
+  artifacts:
+    paths:
+      - public
+    expire_in: 30 days
 
 integration-main:
-    stage: pkgdown-move
-    dependencies:
-        - integration
-    only:
-        - master
-        - main
-    script:
-        - mkdir -p public
-        - 'curl --location --output artifacts.zip --header "JOB-TOKEN: $CI_JOB_TOKEN" "$CI_API_V4_URL/projects/$CI_PROJECT_ID/jobs/artifacts/production/download?job=pages" &&
-          unzip artifacts.zip &&
-          rm artifacts.zip &&
-          echo "copied production artifacts" ||
-          echo "copied production artifacts failed"'
-        - cp -r docs/* public
-    artifacts:
-        paths:
-            - public
-        expire_in: 30 days
+  stage: pkgdown-move
+  dependencies:
+    - integration
+  only:
+    - master
+    - main
+  script:
+    - mkdir -p public
+    - 'curl --location --output artifacts.zip --header "JOB-TOKEN: $CI_JOB_TOKEN" "$CI_API_V4_URL/projects/$CI_PROJECT_ID/jobs/artifacts/production/download?job=pages" &&
+      unzip artifacts.zip &&
+      rm artifacts.zip &&
+      echo "copied production artifacts" ||
+      echo "copied production artifacts failed"'
+    - cp -r docs/* public
+  artifacts:
+    paths:
+      - public
+    expire_in: 30 days
 
 pages:
-    stage: deploy
-    script:
-        - echo "deployment with cache"
-    artifacts:
-        paths:
-            - public
-    only:
-        - master
-        - main
-        - production
-        - test-ci
+  stage: deploy
+  script:
+    - echo "deployment with cache"
+  artifacts:
+    paths:
+      - public
+  only:
+    - master
+    - main
+    - production
+    - test-ci

--- a/inst/gitlab-ci/check-coverage-pkgdown-renv.yml
+++ b/inst/gitlab-ci/check-coverage-pkgdown-renv.yml
@@ -40,11 +40,11 @@ building:
       - check
     expire_in: 30 days
 
-# To have the coverage percentage appear as a gitlab badge follow these
-# instructions:
-# https://docs.gitlab.com/ee/user/project/pipelines/settings.html#test-coverage-parsing
-# The coverage parsing string is
-# Coverage: \d+\.\d+
+# For gitlab versions below 15.0,
+# in order to have the coverage percentage appear as a gitlab badge,
+# you will need to:
+# - Go to your project Settings > CI/CD
+# - Set the coverage parsing string to: Coverage: \d+\.\d+
 
 coverage:
   stage: test

--- a/inst/gitlab-ci/check-coverage-pkgdown.yml
+++ b/inst/gitlab-ci/check-coverage-pkgdown.yml
@@ -1,4 +1,4 @@
-image: {image}
+image: { image }
 
 variables:
   GIT_DEPTH: 10
@@ -8,7 +8,7 @@ variables:
 cache:
   key: global-cache
   paths:
-      - ${R_LIBS_USER}
+    - ${R_LIBS_USER}
 
 stages:
   - build
@@ -29,10 +29,10 @@ building:
     - Rscript -e 'remotes::install_local(upgrade = "never")'
     - R -e 'rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check")'
   artifacts:
-      paths:
-          - check
-      expire_in: 30 days
-      
+    paths:
+      - check
+    expire_in: 30 days
+
 # To have the coverage percentage appear as a gitlab badge follow these
 # instructions:
 # https://docs.gitlab.com/ee/user/project/pipelines/settings.html#test-coverage-parsing
@@ -40,115 +40,116 @@ building:
 # Coverage: \d+\.\d+
 
 coverage:
-    stage: test
-    allow_failure: true
-    when: on_success
-    only:
-        - main
-        - master
-        - production
-    script:
-        - Rscript -e 'remotes::install_local(upgrade = "never")'
-        - Rscript -e 'remotes::install_cran(c("covr", "DT"), upgrade = "never")'
-        - Rscript -e 'covr::gitlab(quiet = FALSE)'
-    artifacts:
-        paths:
-            - public
-        expire_in: 30 days
+  stage: test
+  allow_failure: true
+  when: on_success
+  only:
+    - main
+    - master
+    - production
+  script:
+    - Rscript -e 'remotes::install_local(upgrade = "never")'
+    - Rscript -e 'remotes::install_cran(c("covr", "DT"), upgrade = "never")'
+    - Rscript -e 'covr::gitlab(quiet = FALSE)'
+  coverage: '/Coverage: \d+\.\d+/'
+  artifacts:
+    paths:
+      - public
+    expire_in: 30 days
 
 # To produce a code coverage report as a GitLab page see
 # https://about.gitlab.com/2016/11/03/publish-code-coverage-report-with-gitlab-pages/
 
 integration:
-    stage: pkgdown
-    allow_failure: true
-    when: on_success
-    only:
-        - main
-        - master
-        - production
-        - test-ci
-    script:
-        - Rscript -e 'remotes::install_cran(c("pkgdown"), upgrade = "never")'
-        - Rscript -e 'remotes::install_local(upgrade = "never")'
-        - Rscript -e 'pkgdown::build_site()'
-    artifacts:
-        paths:
-            - docs
-        expire_in: 30 days
+  stage: pkgdown
+  allow_failure: true
+  when: on_success
+  only:
+    - main
+    - master
+    - production
+    - test-ci
+  script:
+    - Rscript -e 'remotes::install_cran(c("pkgdown"), upgrade = "never")'
+    - Rscript -e 'remotes::install_local(upgrade = "never")'
+    - Rscript -e 'pkgdown::build_site()'
+  artifacts:
+    paths:
+      - docs
+    expire_in: 30 days
 
 integration-test:
-    stage: pkgdown-move
-    dependencies:
-        - integration
-    only:
-        - test-ci
-    script:
-        - mkdir -p public/test
-        - 'curl --location --output artifacts.zip --header "JOB-TOKEN: $CI_JOB_TOKEN" "$CI_API_V4_URL/projects/$CI_PROJECT_ID/jobs/artifacts/$CI_DEFAULT_BRANCH/download?job=pages" &&
-          unzip artifacts.zip &&
-          rm artifacts.zip &&
-          echo "copied $CI_DEFAULT_BRANCH artifacts" ||
-          echo "copied $CI_DEFAULT_BRANCH artifacts failed"'
-        - 'curl --location --output artifacts.zip --header "JOB-TOKEN: $CI_JOB_TOKEN" "$CI_API_V4_URL/projects/$CI_PROJECT_ID/jobs/artifacts/production/download?job=pages" &&
-          unzip artifacts.zip &&
-          rm artifacts.zip &&
-          echo "copied production artifacts" ||
-          echo "copied production artifacts failed"'
-        - cp -r docs/* public/test
-    artifacts:
-        paths:
-            - public
-        expire_in: 30 days
+  stage: pkgdown-move
+  dependencies:
+    - integration
+  only:
+    - test-ci
+  script:
+    - mkdir -p public/test
+    - 'curl --location --output artifacts.zip --header "JOB-TOKEN: $CI_JOB_TOKEN" "$CI_API_V4_URL/projects/$CI_PROJECT_ID/jobs/artifacts/$CI_DEFAULT_BRANCH/download?job=pages" &&
+      unzip artifacts.zip &&
+      rm artifacts.zip &&
+      echo "copied $CI_DEFAULT_BRANCH artifacts" ||
+      echo "copied $CI_DEFAULT_BRANCH artifacts failed"'
+    - 'curl --location --output artifacts.zip --header "JOB-TOKEN: $CI_JOB_TOKEN" "$CI_API_V4_URL/projects/$CI_PROJECT_ID/jobs/artifacts/production/download?job=pages" &&
+      unzip artifacts.zip &&
+      rm artifacts.zip &&
+      echo "copied production artifacts" ||
+      echo "copied production artifacts failed"'
+    - cp -r docs/* public/test
+  artifacts:
+    paths:
+      - public
+    expire_in: 30 days
 
 integration-production:
-    stage: pkgdown-move
-    dependencies:
-        - integration
-    only:
-        - production
-    script:
-        - mkdir -p public/production
-        - 'curl --location --output artifacts.zip --header "JOB-TOKEN: $CI_JOB_TOKEN" "$CI_API_V4_URL/projects/$CI_PROJECT_ID/jobs/artifacts/$CI_DEFAULT_BRANCH/download?job=pages" &&
-          unzip artifacts.zip &&
-          rm artifacts.zip &&
-          echo "copied $CI_DEFAULT_BRANCH artifacts" ||
-          echo "copied $CI_DEFAULT_BRANCH artifacts failed"'
-        - cp -r docs/* public/production
-    artifacts:
-        paths:
-            - public
-        expire_in: 30 days
+  stage: pkgdown-move
+  dependencies:
+    - integration
+  only:
+    - production
+  script:
+    - mkdir -p public/production
+    - 'curl --location --output artifacts.zip --header "JOB-TOKEN: $CI_JOB_TOKEN" "$CI_API_V4_URL/projects/$CI_PROJECT_ID/jobs/artifacts/$CI_DEFAULT_BRANCH/download?job=pages" &&
+      unzip artifacts.zip &&
+      rm artifacts.zip &&
+      echo "copied $CI_DEFAULT_BRANCH artifacts" ||
+      echo "copied $CI_DEFAULT_BRANCH artifacts failed"'
+    - cp -r docs/* public/production
+  artifacts:
+    paths:
+      - public
+    expire_in: 30 days
 
 integration-main:
-    stage: pkgdown-move
-    dependencies:
-        - integration
-    only:
-        - main
-        - master
-    script:
-        - mkdir -p public
-        - 'curl --location --output artifacts.zip --header "JOB-TOKEN: $CI_JOB_TOKEN" "$CI_API_V4_URL/projects/$CI_PROJECT_ID/jobs/artifacts/production/download?job=pages" &&
-          unzip artifacts.zip &&
-          rm artifacts.zip &&
-          echo "copied production artifacts" ||
-          echo "copied production artifacts failed"'
-        - cp -r docs/* public
-    artifacts:
-        paths:
-            - public
-        expire_in: 30 days
+  stage: pkgdown-move
+  dependencies:
+    - integration
+  only:
+    - main
+    - master
+  script:
+    - mkdir -p public
+    - 'curl --location --output artifacts.zip --header "JOB-TOKEN: $CI_JOB_TOKEN" "$CI_API_V4_URL/projects/$CI_PROJECT_ID/jobs/artifacts/production/download?job=pages" &&
+      unzip artifacts.zip &&
+      rm artifacts.zip &&
+      echo "copied production artifacts" ||
+      echo "copied production artifacts failed"'
+    - cp -r docs/* public
+  artifacts:
+    paths:
+      - public
+    expire_in: 30 days
 
 pages:
-    stage: deploy
-    script:
-        - echo "deployment with cache"
-    artifacts:
-        paths:
-            - public
-    only:
-        - main
-        - master
-        - production
-        - test-ci
+  stage: deploy
+  script:
+    - echo "deployment with cache"
+  artifacts:
+    paths:
+      - public
+  only:
+    - main
+    - master
+    - production
+    - test-ci

--- a/inst/gitlab-ci/check-coverage-pkgdown.yml
+++ b/inst/gitlab-ci/check-coverage-pkgdown.yml
@@ -33,11 +33,11 @@ building:
       - check
     expire_in: 30 days
 
-# To have the coverage percentage appear as a gitlab badge follow these
-# instructions:
-# https://docs.gitlab.com/ee/user/project/pipelines/settings.html#test-coverage-parsing
-# The coverage parsing string is
-# Coverage: \d+\.\d+
+# For gitlab versions below 15.0,
+# in order to have the coverage percentage appear as a gitlab badge,
+# you will need to:
+# - Go to your project Settings > CI/CD
+# - Set the coverage parsing string to: Coverage: \d+\.\d+
 
 coverage:
   stage: test

--- a/tests/testthat/gitlab-ci.yml
+++ b/tests/testthat/gitlab-ci.yml
@@ -8,7 +8,7 @@ variables:
 cache:
   key: global-cache
   paths:
-      - ${R_LIBS_USER}
+    - ${R_LIBS_USER}
 
 stages:
   - build
@@ -29,9 +29,9 @@ building:
     - Rscript -e 'remotes::install_local(upgrade = "never")'
     - R -e 'rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check")'
   artifacts:
-      paths:
-          - check
-      expire_in: 30 days
+    paths:
+      - check
+    expire_in: 30 days
 
 # To have the coverage percentage appear as a gitlab badge follow these
 # instructions:
@@ -40,115 +40,116 @@ building:
 # Coverage: \d+\.\d+
 
 coverage:
-    stage: test
-    allow_failure: true
-    when: on_success
-    only:
-        - main
-        - master
-        - production
-    script:
-        - Rscript -e 'remotes::install_local(upgrade = "never")'
-        - Rscript -e 'remotes::install_cran(c("covr", "DT"), upgrade = "never")'
-        - Rscript -e 'covr::gitlab(quiet = FALSE)'
-    artifacts:
-        paths:
-            - public
-        expire_in: 30 days
+  stage: test
+  allow_failure: true
+  when: on_success
+  only:
+    - main
+    - master
+    - production
+  script:
+    - Rscript -e 'remotes::install_local(upgrade = "never")'
+    - Rscript -e 'remotes::install_cran(c("covr", "DT"), upgrade = "never")'
+    - Rscript -e 'covr::gitlab(quiet = FALSE)'
+  coverage: '/Coverage: \d+\.\d+/'
+  artifacts:
+    paths:
+      - public
+    expire_in: 30 days
 
 # To produce a code coverage report as a GitLab page see
 # https://about.gitlab.com/2016/11/03/publish-code-coverage-report-with-gitlab-pages/
 
 integration:
-    stage: pkgdown
-    allow_failure: true
-    when: on_success
-    only:
-        - main
-        - master
-        - production
-        - test-ci
-    script:
-        - Rscript -e 'remotes::install_cran(c("pkgdown"), upgrade = "never")'
-        - Rscript -e 'remotes::install_local(upgrade = "never")'
-        - Rscript -e 'pkgdown::build_site()'
-    artifacts:
-        paths:
-            - docs
-        expire_in: 30 days
+  stage: pkgdown
+  allow_failure: true
+  when: on_success
+  only:
+    - main
+    - master
+    - production
+    - test-ci
+  script:
+    - Rscript -e 'remotes::install_cran(c("pkgdown"), upgrade = "never")'
+    - Rscript -e 'remotes::install_local(upgrade = "never")'
+    - Rscript -e 'pkgdown::build_site()'
+  artifacts:
+    paths:
+      - docs
+    expire_in: 30 days
 
 integration-test:
-    stage: pkgdown-move
-    dependencies:
-        - integration
-    only:
-        - test-ci
-    script:
-        - mkdir -p public/test
-        - 'curl --location --output artifacts.zip --header "JOB-TOKEN: $CI_JOB_TOKEN" "$CI_API_V4_URL/projects/$CI_PROJECT_ID/jobs/artifacts/$CI_DEFAULT_BRANCH/download?job=pages" &&
-          unzip artifacts.zip &&
-          rm artifacts.zip &&
-          echo "copied $CI_DEFAULT_BRANCH artifacts" ||
-          echo "copied $CI_DEFAULT_BRANCH artifacts failed"'
-        - 'curl --location --output artifacts.zip --header "JOB-TOKEN: $CI_JOB_TOKEN" "$CI_API_V4_URL/projects/$CI_PROJECT_ID/jobs/artifacts/production/download?job=pages" &&
-          unzip artifacts.zip &&
-          rm artifacts.zip &&
-          echo "copied production artifacts" ||
-          echo "copied production artifacts failed"'
-        - cp -r docs/* public/test
-    artifacts:
-        paths:
-            - public
-        expire_in: 30 days
+  stage: pkgdown-move
+  dependencies:
+    - integration
+  only:
+    - test-ci
+  script:
+    - mkdir -p public/test
+    - 'curl --location --output artifacts.zip --header "JOB-TOKEN: $CI_JOB_TOKEN" "$CI_API_V4_URL/projects/$CI_PROJECT_ID/jobs/artifacts/$CI_DEFAULT_BRANCH/download?job=pages" &&
+      unzip artifacts.zip &&
+      rm artifacts.zip &&
+      echo "copied $CI_DEFAULT_BRANCH artifacts" ||
+      echo "copied $CI_DEFAULT_BRANCH artifacts failed"'
+    - 'curl --location --output artifacts.zip --header "JOB-TOKEN: $CI_JOB_TOKEN" "$CI_API_V4_URL/projects/$CI_PROJECT_ID/jobs/artifacts/production/download?job=pages" &&
+      unzip artifacts.zip &&
+      rm artifacts.zip &&
+      echo "copied production artifacts" ||
+      echo "copied production artifacts failed"'
+    - cp -r docs/* public/test
+  artifacts:
+    paths:
+      - public
+    expire_in: 30 days
 
 integration-production:
-    stage: pkgdown-move
-    dependencies:
-        - integration
-    only:
-        - production
-    script:
-        - mkdir -p public/production
-        - 'curl --location --output artifacts.zip --header "JOB-TOKEN: $CI_JOB_TOKEN" "$CI_API_V4_URL/projects/$CI_PROJECT_ID/jobs/artifacts/$CI_DEFAULT_BRANCH/download?job=pages" &&
-          unzip artifacts.zip &&
-          rm artifacts.zip &&
-          echo "copied $CI_DEFAULT_BRANCH artifacts" ||
-          echo "copied $CI_DEFAULT_BRANCH artifacts failed"'
-        - cp -r docs/* public/production
-    artifacts:
-        paths:
-            - public
-        expire_in: 30 days
+  stage: pkgdown-move
+  dependencies:
+    - integration
+  only:
+    - production
+  script:
+    - mkdir -p public/production
+    - 'curl --location --output artifacts.zip --header "JOB-TOKEN: $CI_JOB_TOKEN" "$CI_API_V4_URL/projects/$CI_PROJECT_ID/jobs/artifacts/$CI_DEFAULT_BRANCH/download?job=pages" &&
+      unzip artifacts.zip &&
+      rm artifacts.zip &&
+      echo "copied $CI_DEFAULT_BRANCH artifacts" ||
+      echo "copied $CI_DEFAULT_BRANCH artifacts failed"'
+    - cp -r docs/* public/production
+  artifacts:
+    paths:
+      - public
+    expire_in: 30 days
 
 integration-main:
-    stage: pkgdown-move
-    dependencies:
-        - integration
-    only:
-        - main
-        - master
-    script:
-        - mkdir -p public
-        - 'curl --location --output artifacts.zip --header "JOB-TOKEN: $CI_JOB_TOKEN" "$CI_API_V4_URL/projects/$CI_PROJECT_ID/jobs/artifacts/production/download?job=pages" &&
-          unzip artifacts.zip &&
-          rm artifacts.zip &&
-          echo "copied production artifacts" ||
-          echo "copied production artifacts failed"'
-        - cp -r docs/* public
-    artifacts:
-        paths:
-            - public
-        expire_in: 30 days
+  stage: pkgdown-move
+  dependencies:
+    - integration
+  only:
+    - main
+    - master
+  script:
+    - mkdir -p public
+    - 'curl --location --output artifacts.zip --header "JOB-TOKEN: $CI_JOB_TOKEN" "$CI_API_V4_URL/projects/$CI_PROJECT_ID/jobs/artifacts/production/download?job=pages" &&
+      unzip artifacts.zip &&
+      rm artifacts.zip &&
+      echo "copied production artifacts" ||
+      echo "copied production artifacts failed"'
+    - cp -r docs/* public
+  artifacts:
+    paths:
+      - public
+    expire_in: 30 days
 
 pages:
-    stage: deploy
-    script:
-        - echo "deployment with cache"
-    artifacts:
-        paths:
-            - public
-    only:
-        - main
-        - master
-        - production
-        - test-ci
+  stage: deploy
+  script:
+    - echo "deployment with cache"
+  artifacts:
+    paths:
+      - public
+  only:
+    - main
+    - master
+    - production
+    - test-ci

--- a/tests/testthat/gitlab-ci.yml
+++ b/tests/testthat/gitlab-ci.yml
@@ -33,11 +33,11 @@ building:
       - check
     expire_in: 30 days
 
-# To have the coverage percentage appear as a gitlab badge follow these
-# instructions:
-# https://docs.gitlab.com/ee/user/project/pipelines/settings.html#test-coverage-parsing
-# The coverage parsing string is
-# Coverage: \d+\.\d+
+# For gitlab versions below 15.0,
+# in order to have the coverage percentage appear as a gitlab badge,
+# you will need to:
+# - Go to your project Settings > CI/CD
+# - Set the coverage parsing string to: Coverage: \d+\.\d+
 
 coverage:
   stage: test


### PR DESCRIPTION
Why:

- In gitlab > 15.0 the instruction `coverage` needs to be added to the coverage stage in order for the coverage badge to work.
- This `coverage` instructions give the regex needed for gitlab to parse the job log and find the line displaying the coverage output.

How:

- Update gitlab-ci.yml templates for package checks

Issue #68