### PR TITLE
fix: Edit .gitlab-ci.yml to update pkgs at the beginning of the pipeline

### DIFF
--- a/inst/gitlab-ci/check-coverage-pkgdown.yml
+++ b/inst/gitlab-ci/check-coverage-pkgdown.yml
@@ -28,7 +28,7 @@ building:
     - mkdir -p $R_LIBS_USER
     - Rscript -e 'install.packages("remotes")'
     - Rscript -e 'install.packages("rcmdcheck")'
-    - Rscript -e 'remotes::install_local(upgrade = "never")'
+    - Rscript -e 'remotes::install_local(upgrade = "always")'
     - R -e 'rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check")'
   artifacts:
     paths:

--- a/tests/testthat/gitlab-ci-check-coverage-pkgdown.yml
+++ b/tests/testthat/gitlab-ci-check-coverage-pkgdown.yml
@@ -28,7 +28,7 @@ building:
     - mkdir -p $R_LIBS_USER
     - Rscript -e 'install.packages("remotes")'
     - Rscript -e 'install.packages("rcmdcheck")'
-    - Rscript -e 'remotes::install_local(upgrade = "never")'
+    - Rscript -e 'remotes::install_local(upgrade = "always")'
     - R -e 'rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check")'
   artifacts:
     paths:


### PR DESCRIPTION
tags: fix, ci

Why?

* The last version of R packages were not installed at the beggining of the CI pipeline

What?

* It caused some problems when new features were added to some packages

Issues

issue #91