### PR TITLE
chore: bump to 2.1.0

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -24,3 +24,4 @@ Dockerfile
 ^CRAN-RELEASE$
 ^CRAN-SUBMISSION$
 ^LICENSE\.md$
+^pkgdown$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gitlabr
 Title: Access to the 'GitLab' API
-Version: 2.0.1.9010
+Version: 2.1.0
 Authors@R: c(
     person("Jirka", "Lewandowski", , "jirka.lewandowski@wzb.eu", role = "aut"),
     person("Sébastien", "Rochette", , "sebastienrochettefr@gmail.com", role = c("aut", "cre"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,7 +39,6 @@ Suggests:
     yaml
 VignetteBuilder: 
     knitr
-Config/Needs/website: ThinkR-open/thinkrtemplate
 Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# gitlabr (development)
+# gitlabr 2.1.0
 
 ## Breaking changes
 

--- a/dev/cran-comments-history.md
+++ b/dev/cran-comments-history.md
@@ -1,3 +1,12 @@
+# gitlabr 2.1.0
+## R CMD check results
+
+0 errors | 0 warnings | 1 note
+
+* Maintainer email was changed for my personal address, instead of my professional one.
+* OK on GitHub Actions, rhub, winbuilder and macbuilder
+* Fixes notes on CRAN checks: "Lost braces; missing escapes or markup?"
+
 # gitlabr 2.0.1
 
 * This release deals with notes in checks on <https://cran.r-project.org/web/checks/check_results_gitlabr.html> created by the last modification of CRAN checks concerning HTML5

--- a/dev/dev_history.R
+++ b/dev/dev_history.R
@@ -33,6 +33,7 @@ pkgdown::check_pkgdown()
 usethis::use_build_ignore("_pkgdown.yml")
 usethis::use_git_ignore("public")
 usethis::use_build_ignore("public/")
+usethis::use_build_ignore("pkgdown/")
 options(rmarkdown.html_vignette.check_title = FALSE)
 pkgdown::build_site()
 


### PR DESCRIPTION
- [x] Wait for acceptation on CRAN
- [x] Accept PR and Tag commit to v2.1.0
- [x] Add release with NEWS notes

- [x] Then: Set dev version

closes #102